### PR TITLE
Potential fix for code scanning alert no. 4: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/edu/isi/oba/utils/ObaUtils.java
+++ b/src/main/java/edu/isi/oba/utils/ObaUtils.java
@@ -18,7 +18,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -105,10 +104,12 @@ public class ObaUtils {
 				String fileName = ze.getName();
 				File newFile = new File(outputFolder + File.separator + fileName);
 
-				// Check whether bad or malicious entry exists in zip file. Log an exit, if so.
+				// Check whether bad or malicious entry exists in zip file. Log and exit, if so.
 				File canonicalOutputDir = new File(outputFolder).getCanonicalFile();
 				File canonicalDestFile = newFile.getCanonicalFile();
-				if (!canonicalDestFile.getPath().startsWith(canonicalOutputDir.getPath() + File.separator)) {
+				if (!canonicalDestFile
+						.getPath()
+						.startsWith(canonicalOutputDir.getPath() + File.separator)) {
 					FatalErrorHandler.fatal(
 							"Bad zip entry.  Possibly malicious.  Exiting to avoid 'Zip Slip'.");
 				}

--- a/src/main/java/edu/isi/oba/utils/ObaUtils.java
+++ b/src/main/java/edu/isi/oba/utils/ObaUtils.java
@@ -105,8 +105,10 @@ public class ObaUtils {
 				String fileName = ze.getName();
 				File newFile = new File(outputFolder + File.separator + fileName);
 
-				// Check whether bad or malicious entry exists in zip file.  Log an exit, if so.
-				if (!newFile.toPath().normalize().startsWith(Path.of(outputFolder, File.separator))) {
+				// Check whether bad or malicious entry exists in zip file. Log an exit, if so.
+				File canonicalOutputDir = new File(outputFolder).getCanonicalFile();
+				File canonicalDestFile = newFile.getCanonicalFile();
+				if (!canonicalDestFile.getPath().startsWith(canonicalOutputDir.getPath() + File.separator)) {
 					FatalErrorHandler.fatal(
 							"Bad zip entry.  Possibly malicious.  Exiting to avoid 'Zip Slip'.");
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/cweedall/onto-oas/security/code-scanning/4](https://github.com/cweedall/onto-oas/security/code-scanning/4)

To fix this problem:
- For each `ZipEntry`, after constructing the output file object (currently `File newFile = new File(outputFolder + File.separator + fileName);`), **normalize and resolve the absolute output file path** and ensure it is contained within the intended root extraction directory (`outputFolder`).
- The directory traversal check should compare the normalized canonical paths of the output file and output directory (i.e., `outputFile.getCanonicalPath().startsWith(outputDir.getCanonicalPath() + File.separator)`).
- This validation must be done immediately before any file/directory creation or writing.
- Update the path checking logic so it correctly validates that a file to be extracted does not escape the designated directory.

Required changes:
- Update the vulnerable check in the `unZipIt` method to use canonical paths for both the output directory and each extracted file, and compare properly with the directory plus separator.  
- No new imports are required beyond what’s already included.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
